### PR TITLE
Manager: Fix the translation issue of "Magic Mount" in zh-CN

### DIFF
--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,8 +64,8 @@
     <string name="send_log">发送日志</string>
     <string name="safe_mode">安全模式</string>
     <string name="reboot_to_apply">重启生效</string>
-    <string name="home_module_mount">模組系統</string>
-    <string name="home_magic_mount">魔法坐騎</string>
+    <string name="home_module_mount">模块系统</string>
+    <string name="home_magic_mount">Magic Mount</string>
     <string name="module_magisk_conflict">因与Magisk有冲突，所有模块不可用！</string>
     <string name="home_next_kernelsu">🔥 Next 构建</string>
     <string name="home_next_kernelsu_repo">https://github.com/rifsxd/KernelSU-Next</string>


### PR DESCRIPTION
Correct the "module system" of traditional Chinese fonts to simplified Chinese; Correct the translation of Magic Mount from ' 魔法坐骑 ' to 'Magic Mount', as it leans more towards a technology rather than a paragraph. Translating it as' 魔法坐骑 'is actually quite ridiculous