### PR TITLE
ksud: fix /debug_ramdisk not mounting

### DIFF
--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -3,8 +3,35 @@ use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, ksucalls, restorecon, utils};
 use anyhow::{Context, Result};
 use log::{info, warn};
-use rustix::fs::{mount, MountFlags};
+use rustix::{fd::AsFd, fs::CWD, fs::MountFlags, mount::*};
 use std::path::Path;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn mount_tmpfs() -> Result<()> {
+    info!("mount tmpfs on {}", TEMP_DIR);
+    if let Result::Ok(fs) = fsopen("tmpfs", FsOpenFlags::FSOPEN_CLOEXEC) {
+        let fs = fs.as_fd();
+        fsconfig_set_string(fs, "source", KSU_MOUNT_SOURCE)?;
+        fsconfig_create(fs)?;
+        let mount = fsmount(fs, FsMountFlags::FSMOUNT_CLOEXEC, MountAttrFlags::empty())?;
+        move_mount(
+            mount.as_fd(),
+            "",
+            CWD,
+            TEMP_DIR,
+            MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+        )?;
+    } else {
+        mount(
+            KSU_MOUNT_SOURCE,
+            TEMP_DIR,
+            "tmpfs",
+            MountFlags::empty(),
+            "",
+        )?;
+    }
+    Ok(())
+}
 
 pub fn on_post_data_fs() -> Result<()> {
     ksucalls::report_post_fs_data();
@@ -69,7 +96,7 @@ pub fn on_post_data_fs() -> Result<()> {
 
     // mount temp dir
     if !Path::new(NO_TMPFS_PATH).exists() {
-        if let Err(e) = mount(KSU_MOUNT_SOURCE, TEMP_DIR, "tmpfs", MountFlags::empty(), "") {
+        if let Err(e) = mount_tmpfs() {
             warn!("do temp dir mount failed: {}", e);
         }
     } else {


### PR DESCRIPTION
Bring back mount_tmpfs() in
https://github.com/tiann/KernelSU/blob/a3df721b845f288a731916fc7777efeefb033af7/userspace/ksud/src/mount.rs#L158
to allow both legacy and new implementations.

This fixes /debug_ramdisk not mounting for certain devices on magic mount.

Reference to original usage in KernelSU:
https://github.com/tiann/KernelSU/blob/69f31abd62e4f275bb33c9b478961d09231f154d/userspace/ksud/src/init_event.rs#L194

mount.rs which was brought back in https://github.com/rifsxd/KernelSU-Next/commit/bff23c691340e84d47997972f145045ec84a17f2 is now unused so it can also be safely removed.